### PR TITLE
Add TypeScript types entry to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.es.js",
-    "require": "./dist/index.cjs.js"
+    "require": "./dist/index.cjs.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change ensures that the `types` field is included in the `exports` object, which helps with TypeScript type definitions.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R14): Added the `types` field to the `exports` object to include TypeScript type definitions.