### PR TITLE
fix: add linkTo prop to ContactCard

### DIFF
--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -17,6 +17,7 @@ interface ContactCardProps {
   showActionButtons?: boolean;
   role?: { label: string; color: string };
   status?: { label: string; color: string; icon?: React.ReactNode };
+  linkTo?: string;
 }
 
 export const ContactCard: React.FC<ContactCardProps> = ({
@@ -29,6 +30,7 @@ export const ContactCard: React.FC<ContactCardProps> = ({
   showActionButtons = true,
   role,
   status,
+  linkTo,
 }) => {
   const getInitials = (name: string) => {
     const [firstName, lastName] = name.split(" ");
@@ -36,7 +38,7 @@ export const ContactCard: React.FC<ContactCardProps> = ({
   };
 
   return (
-    <Card>
+    <Card href={linkTo ?? '#'} className="cursor-pointer">
       <div className="flex justify-between items-start">
         <div className="flex items-center space-x-4">
           <Avatar

--- a/src/stories/ContactCard.stories.tsx
+++ b/src/stories/ContactCard.stories.tsx
@@ -23,6 +23,7 @@ export const Default: Story = {
     ],
     email: "john.doe@example.com",
     phone: "555-555-5555",
+    linkTo: "https://google.com",
   },
 };
 
@@ -36,6 +37,7 @@ export const WithoutAddress: Story = {
     ],
     email: "john.doe@example.com",
     phone: "555-555-5555",
+    linkTo: "https://google.com",
   },
 };
 
@@ -46,6 +48,7 @@ export const WithoutActions: Story = {
     address: "Austin",
     email: "john.doe@example.com",
     phone: "555-555-5555",
+    linkTo: "https://google.com",
   },
 };
 
@@ -59,6 +62,7 @@ export const WithoutAvatar: Story = {
     ],
     email: "john.doe@example.com",
     phone: "555-555-5555",
+    linkTo: "https://google.com",
   },
 };
 
@@ -74,6 +78,7 @@ export const WithoutActionButtons: Story = {
     email: "john.doe@example.com",
     phone: "555-555-5555",
     showActionButtons: false,
+    linkTo: "https://google.com",
   },
 };
 
@@ -85,10 +90,31 @@ export const WithRole: Story = {
     email: "john.doe@example.com",
     phone: "555-555-5555",
     role: { label: "Manager", color: "purple" },
+    linkTo: "https://google.com",
   },
 };
 
 export const WithStatus: Story = {
+  args: {
+    avatar: "https://i.pravatar.cc/300",
+    name: "John Doe",
+    address: "Austin",
+    email: "john.doe@example.com",
+    phone: "555-555-5555",
+    status: {
+      label: "Pending",
+      color: "yellow",
+      icon: <HiCheckCircle className="h-4 w-4" />,
+    },
+    actions: [
+      { label: "Approve", onClick: () => console.log("Approve") },
+      { label: "Reject", onClick: () => console.log("Reject") },
+    ],
+    linkTo: "https://google.com",
+  },
+};
+
+export const WithoutLink: Story = {
   args: {
     avatar: "https://i.pravatar.cc/300",
     name: "John Doe",


### PR DESCRIPTION
This pull request introduces a new `linkTo` property to the `ContactCard` component in `src/components/ContactCard.tsx` and updates the corresponding stories in `src/stories/ContactCard.stories.tsx` to reflect this new property.

Key changes include:

### Component Updates:
* Added `linkTo` property to the `ContactCardProps` interface and utilized it in the `ContactCard` component to make the card clickable and redirect to the specified link. (`src/components/ContactCard.tsx`) [[1]](diffhunk://#diff-4c6fea04ba2e1e940a5a581c06f84fb3bd364a0d49bd4dadaa0b0cc0754815b4R20) [[2]](diffhunk://#diff-4c6fea04ba2e1e940a5a581c06f84fb3bd364a0d49bd4dadaa0b0cc0754815b4R33-R41)

### Story Updates:
* Updated various stories to include the new `linkTo` property with a sample link ("https://google.com"). (`src/stories/ContactCard.stories.tsx`) [[1]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR26) [[2]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR40) [[3]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR51) [[4]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR65) [[5]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR81) [[6]](diffhunk://#diff-c6f939482c2ca270c390852be1ddfde379284e202776e5a0a46f2c536e88032dR93-R117)