### PR TITLE
fix: make tags prop optional

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Card } from "flowbite-react";
 
 interface NoteCardProps {
-  tags: { label: string; color: string }[];
+  tags?: { label: string; color: string }[];
   title: string;
   content: string;
   author: string;
@@ -22,16 +22,18 @@ export const NoteCard: React.FC<NoteCardProps> = ({
 }) => {
   return (
     <Card className={`bg-white dark:bg-gray-800 ${className}`}>
-      <div className="flex flex-wrap gap-1 mb-2">
-        {tags.map((tag, index) => (
-          <span
-            key={index}
-            className={`text-xs font-semibold px-2 py-1 rounded-full bg-${tag.color}-100 text-${tag.color}-700 dark:bg-${tag.color}-700 dark:text-${tag.color}-100`}
-          >
-            {tag.label}
-          </span>
-        ))}
-      </div>
+      {tags && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {tags.map((tag, index) => (
+            <span
+              key={index}
+              className={`text-xs font-semibold px-2 py-1 rounded-full bg-${tag.color}-100 text-${tag.color}-700 dark:bg-${tag.color}-700 dark:text-${tag.color}-100`}
+            >
+              {tag.label}
+            </span>
+          ))}
+        </div>
+      )}
       <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
         {title}
       </h3>

--- a/src/stories/NoteCard.stories.tsx
+++ b/src/stories/NoteCard.stories.tsx
@@ -56,3 +56,15 @@ export const WithMultipleTags: Story = {
     avatar: "https://i.pravatar.cc/300",
   },
 };
+
+export const WithoutTags: Story = {
+  args: {
+    title: "Building a Responsive Website",
+    content:
+      "Responsive web design is an approach to web design that makes web pages render well on a variety of devices and window or screen sizes...",
+    author: "Alice Johnson",
+    time: "3 days ago",
+    avatar: "https://i.pravatar.cc/300",
+  },
+};
+


### PR DESCRIPTION
This pull request includes several updates to the `NoteCard` component and its associated storybook. The changes primarily focus on making the `tags` property optional and adding a new story to demonstrate the component without tags.

Updates to `NoteCard` component:

* Made the `tags` property optional in the `NoteCardProps` interface to allow the component to be used without tags. (`src/components/NoteCard.tsx`)
* Added a conditional rendering block to display tags only if they are provided. (`src/components/NoteCard.tsx`) [[1]](diffhunk://#diff-6074dface9b4303921203f7169de2e7225edc49dacdb1c723a5d719a35fadadfR25) [[2]](diffhunk://#diff-6074dface9b4303921203f7169de2e7225edc49dacdb1c723a5d719a35fadadfR36)

Updates to storybook:

* Added a new story `WithoutTags` to demonstrate the `NoteCard` component without any tags. (`src/stories/NoteCard.stories.tsx`)

Screenshots:
![image](https://github.com/user-attachments/assets/18a924d2-fc00-4451-8b94-3e1ea60f58f2)