### PR TITLE
Enhance JsonViewer with Internal State Management

### DIFF
--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -2,17 +2,27 @@ import { FC, ReactNode, useState } from 'react';
 import { Button, ButtonProps } from 'flowbite-react';
 import JsonViewerModal from './JsonViewerModal';
 
-export interface JsonViewerProps {
+interface BaseJsonViewerProps {
   data: any;
   title: string;
   buttonLabel?: ReactNode;
   buttonProps?: ButtonProps;
-  isOpen?: boolean;
-  onOpenChange?: (open: boolean) => void;
   dismissible?: boolean;
   invalidDataMessage?: string;
   allowCopy?: boolean;
 }
+
+interface UncontrolledJsonViewerProps extends BaseJsonViewerProps {
+  isOpen?: undefined;
+  onOpenChange?: undefined;
+}
+
+interface ControlledJsonViewerProps extends BaseJsonViewerProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export type JsonViewerProps = ControlledJsonViewerProps | UncontrolledJsonViewerProps;
 
 const JsonViewer: FC<JsonViewerProps> = ({
   data,

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -7,19 +7,18 @@ interface BaseJsonViewerProps {
   title: string;
   buttonLabel?: ReactNode;
   buttonProps?: ButtonProps;
-  dismissible?: boolean;
   invalidDataMessage?: string;
   allowCopy?: boolean;
 }
 
 interface UncontrolledJsonViewerProps extends BaseJsonViewerProps {
-  isOpen?: undefined;
-  onOpenChange?: undefined;
+  show?: undefined;
+  onClose?: undefined;
 }
 
 interface ControlledJsonViewerProps extends BaseJsonViewerProps {
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
+  show: boolean;
+  onClose: () => void;
 }
 
 export type JsonViewerProps = ControlledJsonViewerProps | UncontrolledJsonViewerProps;
@@ -29,35 +28,41 @@ const JsonViewer: FC<JsonViewerProps> = ({
   title,
   buttonLabel = 'View JSON',
   buttonProps,
-  isOpen: controlledIsOpen,
-  onOpenChange,
-  dismissible,
+  show: controlledShow,
+  onClose,
   invalidDataMessage,
   allowCopy,
 }) => {
-  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
+  const [uncontrolledShow, setUncontrolledShow] = useState(false);
   
-  const isControlled = controlledIsOpen !== undefined;
-  const isModalOpen = isControlled ? controlledIsOpen : uncontrolledIsOpen;
+  const isControlled = controlledShow !== undefined;
+  const modalShow = isControlled ? controlledShow : uncontrolledShow;
   
-  const handleOpenChange = (open: boolean) => {
+  const handleClose = () => {
     if (!isControlled) {
-      setUncontrolledIsOpen(open);
+      setUncontrolledShow(false);
     }
-    onOpenChange?.(open);
+    onClose?.();
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (isControlled) {
+      buttonProps?.onClick?.(event);
+    } else {
+      setUncontrolledShow(true);
+    }
   };
 
   return (
     <>
-      <Button {...buttonProps} onClick={() => handleOpenChange(true)}>
+      <Button {...buttonProps} onClick={handleClick}>
         {buttonLabel}
       </Button>
       <JsonViewerModal
-        isOpen={isModalOpen}
-        onClose={() => handleOpenChange(false)}
+        show={modalShow}
+        onClose={handleClose}
         title={title}
         data={data}
-        dismissible={dismissible}
         invalidDataMessage={invalidDataMessage}
         allowCopy={allowCopy}
       />

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -1,14 +1,14 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useState } from 'react';
 import { Button, ButtonProps } from 'flowbite-react';
 import JsonViewerModal from './JsonViewerModal';
 
 export interface JsonViewerProps {
   data: any;
-  title?: string;
+  title: string;
   buttonLabel?: ReactNode;
   buttonProps?: ButtonProps;
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
   dismissible?: boolean;
   invalidDataMessage?: string;
   allowCopy?: boolean;
@@ -19,20 +19,32 @@ const JsonViewer: FC<JsonViewerProps> = ({
   title,
   buttonLabel = 'View JSON',
   buttonProps,
-  isOpen,
+  isOpen: controlledIsOpen,
   onOpenChange,
   dismissible,
   invalidDataMessage,
   allowCopy,
 }) => {
+  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
+  
+  const isControlled = controlledIsOpen !== undefined;
+  const isModalOpen = isControlled ? controlledIsOpen : uncontrolledIsOpen;
+  
+  const handleOpenChange = (open: boolean) => {
+    if (!isControlled) {
+      setUncontrolledIsOpen(open);
+    }
+    onOpenChange?.(open);
+  };
+
   return (
     <>
-      <Button {...buttonProps} onClick={() => onOpenChange(true)}>
+      <Button {...buttonProps} onClick={() => handleOpenChange(true)}>
         {buttonLabel}
       </Button>
       <JsonViewerModal
-        isOpen={isOpen}
-        onClose={() => onOpenChange(false)}
+        isOpen={isModalOpen}
+        onClose={() => handleOpenChange(false)}
         title={title}
         data={data}
         dismissible={dismissible}

--- a/src/components/JsonViewerModal.tsx
+++ b/src/components/JsonViewerModal.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { Modal, Button, Clipboard } from 'flowbite-react';
-import { HiClipboard } from 'react-icons/hi';
 
 export interface JsonViewerModalProps {
   isOpen: boolean;

--- a/src/components/JsonViewerModal.tsx
+++ b/src/components/JsonViewerModal.tsx
@@ -1,22 +1,21 @@
 import { FC } from 'react';
-import { Modal, Button, Clipboard } from 'flowbite-react';
+import { Button, Clipboard } from 'flowbite-react';
+import Modal from './Modal';
 
 export interface JsonViewerModalProps {
-  isOpen: boolean;
+  show: boolean; 
   onClose: () => void;
   title?: string;
   data: any;
-  dismissible?: boolean;
   invalidDataMessage?: string;
   allowCopy?: boolean;
 }
 
 const JsonViewerModal: FC<JsonViewerModalProps> = ({
-  isOpen,
+  show,
   onClose,
   title = 'JSON Data Viewer',
   data,
-  dismissible = true,
   invalidDataMessage = 'Unable to display data: Invalid or circular JSON structure',
   allowCopy = true,
 }) => {
@@ -31,7 +30,7 @@ const JsonViewerModal: FC<JsonViewerModalProps> = ({
   const formattedJson = getFormattedJson();
 
   return (
-    <Modal show={isOpen} onClose={onClose} size="4xl" dismissible={dismissible}>
+    <Modal show={show} onClose={onClose} size="4xl">
       <Modal.Header>{title}</Modal.Header>
       <Modal.Body className="pl-5 pr-5 pt-2 pb-2">
         <div className="relative">

--- a/src/stories/JsonViewer.stories.tsx
+++ b/src/stories/JsonViewer.stories.tsx
@@ -8,27 +8,29 @@ const meta: Meta<typeof JsonViewer> = {
   component: JsonViewer,
   tags: ['autodocs'],
   argTypes: {
-    buttonLabel: {
-      control: 'text',
-      description: 'Text to display on the button',
-    },
-    title: {
-      control: 'text',
-      description: 'Title for the modal (required)',
-      required: true,
-    },
     data: {
       control: 'object',
       description: 'JSON data to display',
+    },
+    title: {
+      control: 'text',
+      description: 'Title for the modal',
+      required: true,
+    },
+    buttonLabel: {
+      control: 'text',
+      description: 'Text to display on the button',
     },
     buttonProps: {
       control: 'object',
       description: 'Props to pass to the button component',
     },
-    dismissible: {
+    show: {
       control: 'boolean',
-      description: 'Whether the modal can be dismissed by clicking outside or pressing ESC',
-      defaultValue: true,
+      description: 'Optional controlled state for the modal. If not provided, the component manages its own state.',
+    },
+    onClose: {
+      description: 'Optional callback fired when the modal closes. Required if show is provided.',
     },
     invalidDataMessage: {
       control: 'text',
@@ -38,13 +40,6 @@ const meta: Meta<typeof JsonViewer> = {
       control: 'boolean',
       description: 'Whether to show the copy button',
       defaultValue: true,
-    },
-    isOpen: {
-      control: 'boolean',
-      description: 'Optional controlled state for the modal. If not provided, the component manages its own state.',
-    },
-    onOpenChange: {
-      description: 'Optional callback fired when the modal open state changes. Required if isOpen is provided.',
     },
   },
 };
@@ -72,11 +67,11 @@ const JsonViewerTemplate: React.FC<{ args: any }> = ({ args }) => {
 
 // Add a template for controlled behavior demonstration
 const ControlledJsonViewerTemplate: React.FC<{ args: any }> = ({ args }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [show, setShow] = useState(false);
 
   return (
     <div className="p-4">
-      <JsonViewer {...args} isOpen={isOpen} onOpenChange={setIsOpen} />
+      <JsonViewer {...args} show={show} onClose={() => setShow(false)} />
     </div>
   );
 };
@@ -91,7 +86,22 @@ export const Default: Story = {
 };
 
 export const ControlledState: Story = {
-  render: (args) => <ControlledJsonViewerTemplate args={args} />,
+  render: function ControlledStateStory(args) {
+    const [show, setShow] = useState(false);
+    return (
+      <div className="p-4">
+        <JsonViewer
+          {...args}
+          show={show}
+          onClose={() => setShow(false)}
+          buttonProps={{
+            onClick: () => setShow(true),
+            ...args.buttonProps
+          }}
+        />
+      </div>
+    );
+  },
   args: {
     data: sampleData,
     title: 'Controlled Modal Example',
@@ -130,19 +140,6 @@ const circularObject: any = {
   name: 'Circular Reference',
 };
 circularObject.self = circularObject;
-
-export const NonDismissibleModal: Story = {
-  render: (args) => <JsonViewerTemplate args={args} />,
-  args: {
-    data: sampleData,
-    title: 'Non-dismissible Modal',
-    buttonLabel: 'Open Non-dismissible Modal',
-    buttonProps: {
-      color: 'warning',
-    },
-    dismissible: false,
-  },
-};
 
 export const InvalidData: Story = {
   render: (args) => <JsonViewerTemplate args={args} />,

--- a/src/stories/JsonViewer.stories.tsx
+++ b/src/stories/JsonViewer.stories.tsx
@@ -14,7 +14,8 @@ const meta: Meta<typeof JsonViewer> = {
     },
     title: {
       control: 'text',
-      description: 'Title for the modal',
+      description: 'Title for the modal (required)',
+      required: true,
     },
     data: {
       control: 'object',
@@ -38,6 +39,13 @@ const meta: Meta<typeof JsonViewer> = {
       description: 'Whether to show the copy button',
       defaultValue: true,
     },
+    isOpen: {
+      control: 'boolean',
+      description: 'Optional controlled state for the modal. If not provided, the component manages its own state.',
+    },
+    onOpenChange: {
+      description: 'Optional callback fired when the modal open state changes. Required if isOpen is provided.',
+    },
   },
 };
 
@@ -55,15 +63,20 @@ const sampleData = {
 
 // Template component to handle state
 const JsonViewerTemplate: React.FC<{ args: any }> = ({ args }) => {
+  return (
+    <div className="p-4">
+      <JsonViewer {...args} />
+    </div>
+  );
+};
+
+// Add a template for controlled behavior demonstration
+const ControlledJsonViewerTemplate: React.FC<{ args: any }> = ({ args }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div className="p-4">
-      <JsonViewer
-        {...args}
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-      />
+      <JsonViewer {...args} isOpen={isOpen} onOpenChange={setIsOpen} />
     </div>
   );
 };
@@ -74,6 +87,15 @@ export const Default: Story = {
     data: sampleData,
     title: 'Sample Data Viewer',
     buttonLabel: 'View JSON',
+  },
+};
+
+export const ControlledState: Story = {
+  render: (args) => <ControlledJsonViewerTemplate args={args} />,
+  args: {
+    data: sampleData,
+    title: 'Controlled Modal Example',
+    buttonLabel: 'Open Controlled Modal',
   },
 };
 

--- a/src/stories/JsonViewerModal.stories.tsx
+++ b/src/stories/JsonViewerModal.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof JsonViewerModal> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    isOpen: {
+    show: {
       control: 'boolean',
       description: 'Controls whether the modal is open or closed',
     },
@@ -32,11 +32,6 @@ const meta: Meta<typeof JsonViewerModal> = {
     onClose: {
       action: 'closed',
       description: 'Callback function when the modal is closed',
-    },
-    dismissible: {
-      control: 'boolean',
-      description: 'Controls whether the modal can be closed by clicking outside or using ESC key',
-      defaultValue: true,
     },
     invalidDataMessage: {
       control: 'text',
@@ -65,15 +60,15 @@ const sampleData = {
 };
 
 const JsonViewerModalTemplate: React.FC<{ args: any }> = ({ args }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [show, setShow] = useState(false);
 
   return (
     <div className="p-4">
-      <Button onClick={() => setIsOpen(true)}>View JSON Data</Button>
+      <Button onClick={() => setShow(true)}>View JSON Data</Button>
       <JsonViewerModal
         {...args}
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        show={show}
+        onClose={() => setShow(false)}
       />
     </div>
   );
@@ -99,15 +94,6 @@ const circularObject: any = {
   name: 'Circular Reference',
 };
 circularObject.self = circularObject;
-
-export const NonDismissible: Story = {
-  render: (args) => <JsonViewerModalTemplate args={args} />,
-  args: {
-    title: 'Non-dismissible Modal',
-    data: sampleData,
-    dismissible: false,
-  },
-};
 
 export const CustomMessageForInvalidData: Story = {
   render: (args) => <JsonViewerModalTemplate args={args} />,


### PR DESCRIPTION
Closes #79 

This pull request includes several enhancements to the `JsonViewer` component, making it more flexible and improving its usability. The most important changes include introducing an optional controlled state for the modal, updating the `JsonViewer` props, and adding new stories to demonstrate the controlled behavior.

Enhancements to `JsonViewer` component:

* [`src/components/JsonViewer.tsx`](diffhunk://#diff-25b172b5a5ec9743ffe3f9c906c9238f94073e0a5e960ac53d108c9acff23f48L1-R11): Added `useState` import and introduced optional controlled state for the modal with `isOpen` and `onOpenChange` props. Updated the component to handle both controlled and uncontrolled states. [[1]](diffhunk://#diff-25b172b5a5ec9743ffe3f9c906c9238f94073e0a5e960ac53d108c9acff23f48L1-R11) [[2]](diffhunk://#diff-25b172b5a5ec9743ffe3f9c906c9238f94073e0a5e960ac53d108c9acff23f48L22-R47)

Updates to `JsonViewerModal`:

* [`src/components/JsonViewerModal.tsx`](diffhunk://#diff-3f4526d67e68318a4b14911fc969ec147144fe72403261d1015b28cbe43a4aacL3): Removed unused `HiClipboard` import to clean up the code.

Storybook updates:

* [`src/stories/JsonViewer.stories.tsx`](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00L17-R18): Updated the `title` prop to be required and added descriptions for the new `isOpen` and `onOpenChange` props. [[1]](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00L17-R18) [[2]](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00R42-R48)
* [`src/stories/JsonViewer.stories.tsx`](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00R66-R79): Added a new template and story to demonstrate the controlled state behavior of the `JsonViewer` component. [[1]](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00R66-R79) [[2]](diffhunk://#diff-9f785dfecd5eb3194b67a89d343d58d264ee6a74c6a8374dc76381365fbddc00R93-R101)