### PR TITLE
Add MetadataViewer component for displaying metadata with customizable options

### DIFF
--- a/src/components/MetadataViewer.tsx
+++ b/src/components/MetadataViewer.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+import { Clipboard } from 'flowbite-react';
+
+export interface MetadataViewerProps {
+  metadata: Record<string, any> | null | undefined;
+  className?: string;
+  title?: string;
+  emptyMessage?: string;
+  borderStyle?: 'solid' | 'dashed' | 'none';
+  showTitle?: boolean;
+  compact?: boolean;
+  allowCopy?: boolean;
+}
+
+const MetadataViewer: FC<MetadataViewerProps> = ({
+  metadata,
+  className = '',
+  title = 'Metadata',
+  emptyMessage = 'No metadata available',
+  borderStyle = 'dashed',
+  showTitle = true,
+  compact = false,
+  allowCopy = true,
+}) => {
+  const borderClass = `border-${borderStyle} border-gray-300 dark:border-gray-600`;
+  const formattedJson = metadata
+    ? JSON.stringify(metadata, null, compact ? 0 : 2)
+    : '';
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {showTitle && (
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+          {title}
+        </h2>
+      )}
+      <div
+        className={`border ${borderClass} rounded-lg ${compact ? 'p-2' : 'p-4'}`}
+      >
+        {metadata && Object.keys(metadata).length > 0 ? (
+          <div className="relative">
+            {allowCopy && (
+              <Clipboard.WithIcon
+                valueToCopy={formattedJson}
+                className="absolute top-2.5 right-0"
+              />
+            )}
+            <pre
+              className={`text-sm text-gray-600 dark:text-gray-300 overflow-x-auto whitespace-pre-wrap break-words max-w-full ${allowCopy ? 'pr-2' : ''}`}
+            >
+              {formattedJson}
+            </pre>
+          </div>
+        ) : (
+          <pre className="text-sm text-gray-600 dark:text-gray-300 text-center">
+            {emptyMessage}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetadataViewer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ export { default as TimeWindowModal, TimeWindow } from "./components/TimeWindowM
 // Data Display
 export { default as JsonViewer } from './components/JsonViewer';
 export { default as JsonViewerModal } from './components/JsonViewerModal';
+export { default as MetadataViewer } from './components/MetadataViewer';
 
 // Theme
 export { grayscaleTheme, ThemeProvider } from './grayscale-theme';

--- a/src/stories/MetadataViewer.stories.tsx
+++ b/src/stories/MetadataViewer.stories.tsx
@@ -1,0 +1,120 @@
+import { Meta, StoryObj } from '@storybook/react';
+import MetadataViewer, { MetadataViewerProps } from '../components/MetadataViewer';
+
+const meta: Meta<typeof MetadataViewer> = {
+  title: 'Components/MetadataViewer',
+  component: MetadataViewer,
+  tags: ['autodocs'],
+  argTypes: {
+    metadata: {
+      control: 'object',
+      description: 'Metadata object to display',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+    title: {
+      control: 'text',
+      description: 'Title text to display above the metadata',
+    },
+    emptyMessage: {
+      control: 'text',
+      description: 'Message to display when no metadata is available',
+    },
+    borderStyle: {
+      control: 'select',
+      options: ['solid', 'dashed', 'none'],
+      description: 'Style of the border around the metadata',
+    },
+    showTitle: {
+      control: 'boolean',
+      description: 'Whether to show the title',
+    },
+    compact: {
+      control: 'boolean',
+      description: 'Display metadata in compact format',
+    },
+    allowCopy: {
+      control: 'boolean',
+      description: 'Whether to show the copy button',
+      defaultValue: true,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MetadataViewer>;
+
+const sampleMetadata = {
+  id: '123',
+  name: 'Sample Metadata',
+  attributes: {
+    color: 'blue',
+    size: 'medium',
+  },
+  tags: ['sample', 'test', 'metadata'],
+};
+
+export const Default: Story = {
+  args: {
+    metadata: sampleMetadata,
+  },
+};
+
+export const NoMetadata: Story = {
+  args: {
+    metadata: null,
+    emptyMessage: 'Custom empty message',
+  },
+};
+
+export const CustomTitle: Story = {
+  args: {
+    metadata: sampleMetadata,
+    title: 'Custom Metadata Title',
+  },
+};
+
+export const CompactView: Story = {
+  args: {
+    metadata: sampleMetadata,
+    compact: true,
+    borderStyle: 'solid',
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    metadata: sampleMetadata,
+    showTitle: false,
+  },
+};
+
+export const BorderStyles: Story = {
+  render: function BorderStylesStory() {
+    const borderStyles: MetadataViewerProps['borderStyle'][] = ['solid', 'dashed', 'none'];
+    
+    return (
+      <div className="grid grid-cols-2 gap-4">
+        {borderStyles.map((style) => (
+          <div key={style || 'none'}>
+            <MetadataViewer
+              metadata={sampleMetadata}
+              title={`Border Style: ${style || 'none'}`}
+              borderStyle={style}
+              compact={true}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+};
+
+export const WithoutCopyButton: Story = {
+  args: {
+    metadata: sampleMetadata,
+    allowCopy: false,
+  },
+};


### PR DESCRIPTION
Closes #82 

---

<details>
<summary>Story book screenshots</summary>

![image](https://github.com/user-attachments/assets/4a27a4cc-9e63-4b15-9f7a-fe179380095c)
![image](https://github.com/user-attachments/assets/5615f31c-540e-4c89-a0c8-ae39b1de5967)
![image](https://github.com/user-attachments/assets/fdbec58d-c37f-462d-a1fc-c57bbd2869d3)
![image](https://github.com/user-attachments/assets/e5ccb841-315a-4545-9bd5-e9dd7c319612)
![image](https://github.com/user-attachments/assets/cd303ea8-5f0f-41ae-a289-58dbcf8848f6)
![image](https://github.com/user-attachments/assets/a5c26448-8a3c-452d-bb70-27893e9f3399)

</details>

This pull request introduces a new `MetadataViewer` component to the codebase, along with its integration and documentation. The most important changes include the addition of the `MetadataViewer` component, its export in the main index file, and the creation of stories for the component in Storybook.

### Addition of `MetadataViewer` component:
* [`src/components/MetadataViewer.tsx`](diffhunk://#diff-c1d5f8ab897362d236a006c43320ec9a236ca058a493d7358500314a8de88fb9R1-R64): Implemented the `MetadataViewer` component which displays metadata with various customization options such as title, border style, compact view, and copy functionality.

### Integration of `MetadataViewer`:
* [`src/index.tsx`](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405R39): Exported the `MetadataViewer` component to make it available for use throughout the project.

### Documentation and examples:
* [`src/stories/MetadataViewer.stories.tsx`](diffhunk://#diff-008e9b489d11211f40f3a0a79775d3df04441423c689a6850c524d548b04063bR1-R120): Added Storybook stories for the `MetadataViewer` component, providing examples of different configurations and use cases.