### PR TITLE
Make npm script naming convention more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Before each push:
 You can manually run the linting fix and build with:
 
 ```bash
-npm run lint-fix
+npm run lint:fix
 npm run build
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "build": "tsup",
     "prepublishOnly": "npm run build",
     "lint": "eslint .",
-    "lint-fix": "eslint . --fix",
+    "lint:fix": "eslint . --fix",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build:storybook": "storybook build",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request includes changes to the `README.md` and `package.json` files to standardize the naming conventions of npm scripts.

Standardizing npm script names:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62): Updated the linting fix command from `npm run lint-fix` to `npm run lint:fix` to match the new naming convention.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R34): Renamed the `lint-fix` script to `lint:fix` and the `build-storybook` script to `build:storybook` for consistency with other script names.