### PR TITLE
fix navbar height after update flowbite

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -46,10 +46,20 @@ export const Modal: React.FC<ModalProps> & {
   }, [show, onClose]);
 
   return (
-    <FlowbiteModal show={show} onClose={onClose} {...rest}>
-      <div ref={modalRef} className="max-h-screen overflow-y-auto">
-        {children}
-      </div>
+    <FlowbiteModal
+      theme={{
+        root: {
+          show: {
+            on: "flex bg-black/50 dark:bg-black/50",
+            off: "hidden",
+          },
+        },
+      }}
+      show={show}
+      onClose={onClose}
+      {...rest}
+    >
+      {children}
     </FlowbiteModal>
   );
 };

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -47,7 +47,7 @@ export const Navbar: FC<NavbarProps> = function ({
   return (
     <FlowbiteNavbar
       fluid
-      className="fixed z-30 w-full bg-white border-b border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+      className="py-0 fixed z-30 w-full bg-white border-b border-gray-200 dark:bg-gray-800 dark:border-gray-700"
     >
       <div className="w-full p-3 lg:px-5 lg:pl-3">
         <div className="flex items-center justify-between">

--- a/src/grayscale-theme/theme.ts
+++ b/src/grayscale-theme/theme.ts
@@ -36,6 +36,10 @@ export const grayscaleTheme = createTheme({
   modal: {
     root: {
       base: "relative h-full w-full p-4 md:h-auto",
+      show: {
+        on: "flex bg-black/50 dark:bg-black/50",
+        off: "hidden",
+      },
     },
     body: {
       base: "p-6 pt-0",


### PR DESCRIPTION
In the new Flowbite version, the Navbar component is added `py-2.5` by default. That increases the height of the sidebar.

I also added backdrop color for Modal in this PR. It has disappeared for the same reason