### PR TITLE
Update navbar

### DIFF
--- a/src/components/Navbar/AppDrawerDropdown.tsx
+++ b/src/components/Navbar/AppDrawerDropdown.tsx
@@ -1,14 +1,42 @@
 import type { FC } from "react";
+import { useState } from "react";
 import { Dropdown } from "flowbite-react";
 import { HiViewGrid } from "react-icons/hi";
 import AppButton from "./AppButton";
+import { Spinner } from "flowbite-react";
 
-interface AppDrawerDropdownProps {
+export interface AppSection {
+  label: string;
   appButtons: { icon: React.ReactNode; title: string; onClick?: () => void }[];
-  onClickExploreProducts?: () => void; // Add optional onClickExploreProducts prop
 }
 
-const AppDrawerDropdown: FC<AppDrawerDropdownProps> = ({ appButtons, onClickExploreProducts }) => {
+interface AppDrawerDropdownProps {
+  sections: AppSection[]; // Update to accept sections
+  onClickExploreProducts?: () => void;
+}
+
+const AppDrawerDropdown: FC<AppDrawerDropdownProps> = ({
+  sections,
+  onClickExploreProducts,
+}) => {
+  const [loadingButtonIndex, setLoadingButtonIndex] = useState<{
+    section: number;
+    button: number;
+  } | null>(null);
+
+  const handleButtonClick = (
+    sectionIndex: number,
+    buttonIndex: number,
+    onClick?: () => void
+  ) =>
+    onClick &&
+    (async () => {
+      setLoadingButtonIndex({ section: sectionIndex, button: buttonIndex });
+      await Promise.resolve(onClick()).finally(() =>
+        setLoadingButtonIndex(null)
+      );
+    })();
+
   return (
     <Dropdown
       arrowIcon={false}
@@ -24,15 +52,37 @@ const AppDrawerDropdown: FC<AppDrawerDropdownProps> = ({ appButtons, onClickExpl
       <div className="block rounded-t-lg bg-white dark:bg-gray-700 py-2 px-4 text-center text-base font-medium text-gray-700 dark:text-gray-400">
         Apps
       </div>
-      <div className="border-b border-gray-300 dark:border-gray-500 mx-4"></div> {/* Darker grey divider */}
-      <div className="grid grid-cols-3 gap-4 p-4 bg-white dark:bg-gray-700 rounded-b-lg">
-        {appButtons.map((appButton, index) => (
-          <AppButton
-            key={index}
-            icon={appButton.icon}
-            title={appButton.title}
-            onClick={appButton.onClick}
-          />
+      <div className="border-b border-gray-300 dark:border-gray-500 mx-4"></div>
+      <div className="space-y-6 p-4 bg-white dark:bg-gray-700 rounded-b-lg">
+        {sections.map((section, sectionIndex) => (
+          <div key={sectionIndex}>
+            <div className="mb-2 text-sm text-gray-600 dark:text-gray-300">
+              {section.label.toUpperCase()}
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              {section.appButtons.map((appButton, buttonIndex) => (
+                <AppButton
+                  key={buttonIndex}
+                  icon={
+                    loadingButtonIndex?.section === sectionIndex &&
+                    loadingButtonIndex?.button === buttonIndex ? (
+                      <Spinner />
+                    ) : (
+                      appButton.icon
+                    )
+                  }
+                  title={appButton.title}
+                  onClick={() =>
+                    handleButtonClick(
+                      sectionIndex,
+                      buttonIndex,
+                      appButton.onClick
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </div>
         ))}
       </div>
     </Dropdown>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -5,7 +5,7 @@ import { DarkThemeToggle, TextInput, Tooltip } from "flowbite-react";
 import { HiMenuAlt1, HiSearch, HiOutlinePhotograph } from "react-icons/hi"; // Import placeholder icon
 import { Navbar as FlowbiteNavbar, NavbarBrand } from "flowbite-react";
 import NotificationBellDropdown from "./NotificationBellDropdown";
-import AppDrawerDropdown from "./AppDrawerDropdown";
+import AppDrawerDropdown, { AppSection } from "./AppDrawerDropdown"; // Import AppSection interface
 import UserDropdown from "./UserDropdown";
 import { NotificationItem } from "./NotificationItem";
 import { useNavbarContext } from "../../context/NavbarContext";
@@ -13,7 +13,7 @@ import { useNavbarContext } from "../../context/NavbarContext";
 interface NavbarProps {
   notifications?: NotificationItem[];
   onViewAllNotifications?: () => void;
-  appButtons?: { icon: React.ReactNode; title: string }[];
+  sections?: AppSection[]; // Replace appButtons with sections
   avatar?: string; // Make avatar optional
   username: string;
   email: string;
@@ -26,7 +26,7 @@ interface NavbarProps {
 export const Navbar: FC<NavbarProps> = function ({
   notifications = [],
   onViewAllNotifications,
-  appButtons = [],
+  sections = [],
   avatar,
   username,
   email,
@@ -94,7 +94,7 @@ export const Navbar: FC<NavbarProps> = function ({
               />
               <DarkThemeToggle />
               <AppDrawerDropdown
-                appButtons={appButtons}
+                sections={sections}
                 onClickExploreProducts={onClickExploreProducts}
               />
               <div className="ml-3">

--- a/src/stories/Navbar.stories.tsx
+++ b/src/stories/Navbar.stories.tsx
@@ -56,51 +56,71 @@ export default meta;
 type Story = StoryObj<typeof Navbar>;
 
 // TODO: Fix sizing of icons in the app button component
-const appButtons = [
+const sections = [
   {
-    icon: <HiShoppingBag className="h-8 w-8" />,
-    title: "Sales",
-    onClick: () => console.log("Sales clicked"),
+    label: "Section 1",
+    appButtons: [
+      {
+        icon: <HiShoppingBag className="h-8 w-8" />,
+        title: "Sales",
+        onClick: () => console.log("Sales clicked"),
+      },
+      {
+        icon: <HiUsers className="h-8 w-8" />,
+        title: "Users",
+        onClick: () => console.log("Users clicked"),
+      },
+    ],
   },
   {
-    icon: <HiUsers className="h-8 w-8" />,
-    title: "Users",
-    onClick: () => console.log("Users clicked"),
+    label: "Section 2",
+    appButtons: [
+      {
+        icon: <HiInbox className="h-8 w-8" />,
+        title: "Inbox",
+        onClick: () => console.log("Inbox clicked"),
+      },
+      {
+        icon: <HiUserCircle className="h-8 w-8" />,
+        title: "Profile",
+        onClick: () => console.log("Profile clicked"),
+      },
+    ],
   },
   {
-    icon: <HiInbox className="h-8 w-8" />,
-    title: "Inbox",
-    onClick: () => console.log("Inbox clicked"),
+    label: "Section 3",
+    appButtons: [
+      {
+        icon: <HiCog className="h-8 w-8" />,
+        title: "Settings",
+        onClick: () => console.log("Settings clicked"),
+      },
+      {
+        icon: <HiArchive className="h-8 w-8" />,
+        title: "Products",
+        onClick: () => console.log("Products clicked"),
+      },
+      {
+        icon: <HiCurrencyDollar className="h-8 w-8" />,
+        title: "Pricing",
+        onClick: () => console.log("Pricing clicked"),
+      },
+    ],
   },
   {
-    icon: <HiUserCircle className="h-8 w-8" />,
-    title: "Profile",
-    onClick: () => console.log("Profile clicked"),
-  },
-  {
-    icon: <HiCog className="h-8 w-8" />,
-    title: "Settings",
-    onClick: () => console.log("Settings clicked"),
-  },
-  {
-    icon: <HiArchive className="h-8 w-8" />,
-    title: "Products",
-    onClick: () => console.log("Products clicked"),
-  },
-  {
-    icon: <HiCurrencyDollar className="h-8 w-8" />,
-    title: "Pricing",
-    onClick: () => console.log("Pricing clicked"),
-  },
-  {
-    icon: <HiOutlineTicket className="h-8 w-8" />,
-    title: "Billing",
-    onClick: () => console.log("Billing clicked"),
-  },
-  {
-    icon: <HiLogout className="h-8 w-8" />,
-    title: "Logout",
-    onClick: () => console.log("Logout clicked"),
+    label: "Section 4",
+    appButtons: [
+      {
+        icon: <HiOutlineTicket className="h-8 w-8" />,
+        title: "Billing",
+        onClick: () => console.log("Billing clicked"),
+      },
+      {
+        icon: <HiLogout className="h-8 w-8" />,
+        title: "Logout",
+        onClick: () => console.log("Logout clicked"),
+      },
+    ],
   },
 ];
 
@@ -124,7 +144,7 @@ const NavbarWithSidebarMenu = () => {
       <Navbar
         logo={icon} // Rename icon to logo
         onViewAllNotifications={() => console.log("View all notifications")}
-        appButtons={appButtons}
+        sections={sections}
         avatar="https://i.pravatar.cc/300?img=6" // Optional avatar
         username="Neil Sims"
         email="neil.sims@flowbite.com"
@@ -154,7 +174,7 @@ export const Default: Story = {
       <Navbar
         logo={icon} // Rename icon to logo
         onViewAllNotifications={() => console.log("View all notifications")}
-        appButtons={appButtons}
+        sections={sections}
         avatar="https://i.pravatar.cc/300?img=6" // Optional avatar
         username="Neil Sims"
         email="neil.sims@flowbite.com"
@@ -179,7 +199,7 @@ export const NoSearch: Story = {
       <Navbar
         logo={icon} // Rename icon to logo
         onViewAllNotifications={() => console.log("View all notifications")}
-        appButtons={appButtons}
+        sections={sections}
         avatar="https://i.pravatar.cc/300?img=6" // Optional avatar
         username="Neil Sims"
         email="neil.sims@flowbite.com"
@@ -196,7 +216,7 @@ export const NoAvatar: Story = {
       <Navbar
         logo={icon} // Rename icon to logo
         onViewAllNotifications={() => console.log("View all notifications")}
-        appButtons={appButtons}
+        sections={sections}
         username="Neil Sims"
         email="neil.sims@flowbite.com"
         userDropdownItems={userDropdownItems}
@@ -211,7 +231,7 @@ export const NoLogo: Story = {
     <NavbarProvider>
       <Navbar
         onViewAllNotifications={() => console.log("View all notifications")}
-        appButtons={appButtons}
+        sections={sections}
         avatar="https://i.pravatar.cc/300?img=6" // Optional avatar
         username="Neil Sims"
         email="neil.sims@flowbite.com"


### PR DESCRIPTION
Related to aspyn-io/ui#1081

This pull request includes changes to the `Navbar` component to improve its functionality by introducing sections for app buttons and adding a loading state for button clicks. The most important changes include updating the `AppDrawerDropdown` component to handle sections, modifying the `Navbar` component to use these sections, and updating the storybook stories to reflect these changes.

Improvements to `AppDrawerDropdown` component:

* [`src/components/Navbar/AppDrawerDropdown.tsx`](diffhunk://#diff-87bb39c3c184f05062a2d5d7b8967cd7764bf5d1961d827d60bde6feb1de4c33R2-R39): Updated to accept sections and handle button clicks with a loading state using `Spinner`. [[1]](diffhunk://#diff-87bb39c3c184f05062a2d5d7b8967cd7764bf5d1961d827d60bde6feb1de4c33R2-R39) [[2]](diffhunk://#diff-87bb39c3c184f05062a2d5d7b8967cd7764bf5d1961d827d60bde6feb1de4c33L27-R87)

Updates to `Navbar` component:

* [`src/components/Navbar/Navbar.tsx`](diffhunk://#diff-3fb9bb17462f833c508f7e5c5d2d9273592b779c587257b5ea04cb1577d32091L8-R16): Replaced `appButtons` with `sections` to integrate the new section-based structure. [[1]](diffhunk://#diff-3fb9bb17462f833c508f7e5c5d2d9273592b779c587257b5ea04cb1577d32091L8-R16) [[2]](diffhunk://#diff-3fb9bb17462f833c508f7e5c5d2d9273592b779c587257b5ea04cb1577d32091L29-R29) [[3]](diffhunk://#diff-3fb9bb17462f833c508f7e5c5d2d9273592b779c587257b5ea04cb1577d32091L97-R97)

Updates to storybook stories:

* [`src/stories/Navbar.stories.tsx`](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL59-R62): Updated stories to use the new `sections` structure instead of `appButtons` and added multiple sections for demonstration. [[1]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL59-R62) [[2]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bR73-R77) [[3]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bR88-R92) [[4]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bR108-R112) [[5]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bR123-R124) [[6]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL127-R147) [[7]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL157-R177) [[8]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL182-R202) [[9]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL199-R219) [[10]](diffhunk://#diff-785a32f5c73f77443c11169f0852d7eaa1c212310804b350bf20546afc71fc5bL214-R234)