### PR TITLE
Fix issue with double-scroll in modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import {
   Modal as FlowbiteModal,
   ModalHeader,
@@ -12,10 +12,14 @@ export interface CustomModalProps extends ModalProps {
 }
 
 // Custom ModalBody component with scrolling support
-const ModalBody: React.FC<React.ComponentPropsWithoutRef<typeof FlowbiteModalBody>> = ({ children, className, ...props }) => {
+const ModalBody: React.FC<
+  React.ComponentPropsWithoutRef<typeof FlowbiteModalBody>
+> = ({ children, className, ...props }) => {
   return (
-    <FlowbiteModalBody 
-      className={`overflow-y-auto flex-1 ${className || ''}`}
+    <FlowbiteModalBody
+      className={`overflow-y-auto overflow-x-hidden flex-1 max-h-[calc(90vh-8rem)] min-h-0 ${
+        className || ""
+      }`}
       {...props}
     >
       {children}
@@ -27,22 +31,23 @@ export const Modal: React.FC<CustomModalProps> & {
   Header: typeof ModalHeader;
   Body: typeof ModalBody;
   Footer: typeof ModalFooter;
-} = ({ show, onClose, children, dismissible = true, ...rest }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-
+} = ({ show, onClose, children, dismissible = true, className, ...rest }) => {
   return (
     <FlowbiteModal
       dismissible={dismissible}
+      className={`!overflow-hidden ${className || ""}`}
       theme={{
         root: {
           show: {
             on: "flex bg-black/50 dark:bg-black/50",
             off: "hidden",
           },
+          base: "fixed top-0 right-0 left-0 z-50 h-modal h-screen overflow-hidden md:inset-0 md:h-full",
         },
         content: {
           base: "relative h-full w-full p-4 md:h-auto",
-          inner: "relative flex max-h-[90vh] flex-col rounded-lg bg-white shadow dark:bg-gray-700",
+          inner:
+            "relative flex max-h-[90vh] min-h-0 flex-col rounded-lg bg-white shadow dark:bg-gray-700",
         },
       }}
       show={show}


### PR DESCRIPTION
Relates to #182 

This pull request updates the `src/components/Modal.tsx` file to enhance the modal component's styling and functionality, including improvements to overflow handling and layout consistency. The changes primarily focus on refining the modal's appearance and behavior.

### Styling and layout improvements:

* `ModalBody` component: Updated to include `max-h-[calc(90vh-8rem)]` and `min-h-0` for better height constraints and added `overflow-x-hidden` to prevent horizontal scrolling.
* `Modal` component: Added `className` support and applied `!overflow-hidden` to the root modal element for improved overflow handling. Updated the `theme` configuration to refine layout properties such as `base` and `inner` for consistent styling across different screen sizes.

### Code cleanup:

* Removed unused `useRef` and `useEffect` imports, simplifying the codebase.