### PR TITLE
Update appointment card to show Schedule Return Service action

### DIFF
--- a/src/components/AppointmentCard.tsx
+++ b/src/components/AppointmentCard.tsx
@@ -46,6 +46,7 @@ interface AppointmentCardProps {
   onSelect?: () => void;
   onRescheduleAppointment?: () => void;
   onCancelAppointment?: () => void;
+  onScheduleReturnService?: () => void;
   onRescheduleWorkOrder?: (workOrderId: string) => void;
   onCancelWorkOrder?: (workOrderId: string) => void;
   showSelectButton?: boolean;
@@ -67,6 +68,7 @@ export const AppointmentCard = ({
   onSelect,
   onRescheduleAppointment,
   onCancelAppointment,
+  onScheduleReturnService,
   onRescheduleWorkOrder,
   onCancelWorkOrder,
   showSelectButton = true,
@@ -216,7 +218,9 @@ export const AppointmentCard = ({
               )}
             </Button>
           )}
-          {editable && (
+          {(onRescheduleAppointment ||
+            onCancelAppointment ||
+            onScheduleReturnService) && (
             <div
               className="flex justify-end"
               onClick={(e) => e.stopPropagation()}
@@ -227,12 +231,21 @@ export const AppointmentCard = ({
                 label={<HiOutlineDotsVertical size={20} />}
                 className="overflow-hidden"
               >
-                <DropdownItem onClick={onRescheduleAppointment}>
-                  Reschedule Appointment
-                </DropdownItem>
-                <DropdownItem onClick={onCancelAppointment}>
-                  Cancel Appointment
-                </DropdownItem>
+                {onRescheduleAppointment && (
+                  <DropdownItem onClick={onRescheduleAppointment}>
+                    Reschedule Appointment
+                  </DropdownItem>
+                )}
+                {onCancelAppointment && (
+                  <DropdownItem onClick={onCancelAppointment}>
+                    Cancel Appointment
+                  </DropdownItem>
+                )}
+                {onScheduleReturnService && (
+                  <DropdownItem onClick={onScheduleReturnService}>
+                    Schedule a Return Service
+                  </DropdownItem>
+                )}
               </Dropdown>
             </div>
           )}

--- a/src/stories/AppointmentCard.stories.tsx
+++ b/src/stories/AppointmentCard.stories.tsx
@@ -16,23 +16,23 @@ type Story = StoryObj<typeof AppointmentCard>;
 const today = new Date();
 
 const workOrders = [
-  { 
-    id: "WO123", 
+  {
+    id: "WO123",
     status: "Active",
     description: "Rodent",
-    duration: "60"
+    duration: "60",
   },
-  { 
-    id: "WO124", 
+  {
+    id: "WO124",
     status: "Pending",
     description: "Flea & Tick",
-    duration: "30"
+    duration: "30",
   },
-  { 
-    id: "WO125", 
+  {
+    id: "WO125",
     status: "Completed",
     description: "German Roach",
-    duration: "90"
+    duration: "90",
   },
 ];
 
@@ -45,7 +45,8 @@ export const Default: Story = {
     userActive: true,
     showIcons: true,
     appointmentId: "APT123",
-    onCalendarClick: (id: string) => console.log("Calendar clicked for appointment:", id),
+    onCalendarClick: (id: string) =>
+      console.log("Calendar clicked for appointment:", id),
   },
 };
 
@@ -65,9 +66,11 @@ export const EditState: Story = {
     onWorkOrderClick: (id: string) => console.log("Clicked Work Order:", id),
     onRescheduleAppointment: () => console.log("Rescheduled Appointment"),
     onCancelAppointment: () => console.log("Canceled Appointment"),
+    onScheduleReturnService: () => console.log("Schedule Return Service"),
     showIcons: true,
     appointmentId: "APT123",
-    onCalendarClick: (id: string) => console.log("Calendar clicked for appointment:", id),
+    onCalendarClick: (id: string) =>
+      console.log("Calendar clicked for appointment:", id),
   },
 };
 
@@ -81,7 +84,8 @@ export const WithoutSelectButton: Story = {
     onSelect: () => console.log("Appointment Selected"),
     showIcons: true,
     appointmentId: "APT123",
-    onCalendarClick: (id: string) => console.log("Calendar clicked for appointment:", id),
+    onCalendarClick: (id: string) =>
+      console.log("Calendar clicked for appointment:", id),
   },
 };
 
@@ -97,7 +101,8 @@ export const SelectedWithStatus: Story = {
     onSelect: () => console.log("Appointment Selected"),
     showIcons: true,
     appointmentId: "APT123",
-    onCalendarClick: (id: string) => console.log("Calendar clicked for appointment:", id),
+    onCalendarClick: (id: string) =>
+      console.log("Calendar clicked for appointment:", id),
   },
 };
 
@@ -110,6 +115,7 @@ export const WithoutIcons: Story = {
     userActive: true,
     showIcons: false,
     appointmentId: "APT123",
-    onCalendarClick: (id: string) => console.log("Calendar clicked for appointment:", id),
+    onCalendarClick: (id: string) =>
+      console.log("Calendar clicked for appointment:", id),
   },
 };


### PR DESCRIPTION
Is related to: https://github.com/aspyn-io/field-service/issues/1603

This pull request enhances the `AppointmentCard` component by adding support for scheduling a return service, both in the component logic and its dropdown menu. It also updates the Storybook stories to demonstrate the new prop and improves code formatting for readability.

**Component enhancements:**

* Added a new optional callback prop `onScheduleReturnService` to the `AppointmentCardProps` interface and passed it through the component. [[1]](diffhunk://#diff-9d0ac0135da68615d8af9fdf05d0ef73659d2abc9870001b10e46f749ce2edfcR49) [[2]](diffhunk://#diff-9d0ac0135da68615d8af9fdf05d0ef73659d2abc9870001b10e46f749ce2edfcR71)
* Updated the dropdown menu in `AppointmentCard` to conditionally display a "Schedule a Return Service" option when the `onScheduleReturnService` prop is provided. [[1]](diffhunk://#diff-9d0ac0135da68615d8af9fdf05d0ef73659d2abc9870001b10e46f749ce2edfcL219-R223) [[2]](diffhunk://#diff-9d0ac0135da68615d8af9fdf05d0ef73659d2abc9870001b10e46f749ce2edfcR234-R248)

**Storybook and formatting updates:**

* Updated the `EditState` story to include the new `onScheduleReturnService` handler, and reformatted several story definitions for improved readability. [[1]](diffhunk://#diff-08c499418b439c068142f32dcfa97a10c99298ba08fd86f573dc8d991e94d418R69-R73) [[2]](diffhunk://#diff-08c499418b439c068142f32dcfa97a10c99298ba08fd86f573dc8d991e94d418L48-R49) [[3]](diffhunk://#diff-08c499418b439c068142f32dcfa97a10c99298ba08fd86f573dc8d991e94d418L84-R88) [[4]](diffhunk://#diff-08c499418b439c068142f32dcfa97a10c99298ba08fd86f573dc8d991e94d418L100-R105) [[5]](diffhunk://#diff-08c499418b439c068142f32dcfa97a10c99298ba08fd86f573dc8d991e94d418L113-R119)
* Minor formatting fix in the `workOrders` array (trailing commas).