### PR TITLE
Update PaymentMethodCard to accept Drawer instead of only DrawerContent

### DIFF
--- a/src/components/PaymentMethodCard.tsx
+++ b/src/components/PaymentMethodCard.tsx
@@ -1,6 +1,4 @@
 import { ReactNode } from "react";
-import { HiDotsVertical } from "react-icons/hi";
-import { Dropdown } from "flowbite-react";
 
 interface PaymentMethodCard {
   cardIcon?: ReactNode;
@@ -9,7 +7,7 @@ interface PaymentMethodCard {
   lastUpdated?: string;
   children?: ReactNode;
   onClick?: () => void;
-  drawerContent?: ReactNode;
+  drawer?: ReactNode;
 }
 
 const UnknownCardIcon = () => (
@@ -35,7 +33,7 @@ export const PaymentMethodCard = ({
   lastUpdated = "22 Aug 2017",
   children,
   onClick,
-  drawerContent,
+  drawer,
 }: PaymentMethodCard) => {
   const CardContent = (
     <>
@@ -55,20 +53,12 @@ export const PaymentMethodCard = ({
           {children}
         </div>
       </div>
-      {drawerContent && (
+      {drawer && (
         <div
           className="mt-4 sm:mt-0 sm:flex-shrink-0"
           onClick={(e) => e.stopPropagation()}
         >
-          <Dropdown
-            inline
-            arrowIcon={false}
-            label={
-              <HiDotsVertical className="h-6 w-6 text-gray-400 hover:text-gray-600" />
-            }
-          >
-            {drawerContent}
-          </Dropdown>
+          {drawer}
         </div>
       )}
     </>

--- a/src/stories/PaymentMethodCard.stories.tsx
+++ b/src/stories/PaymentMethodCard.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import { Dropdown, DropdownItem } from "flowbite-react";
 import PaymentMethodCard from "../components/PaymentMethodCard";
+import { HiDotsVertical } from "react-icons/hi";
 
 const meta: Meta<typeof PaymentMethodCard> = {
   title: "Cards/PaymentMethodCard",
@@ -31,8 +32,8 @@ const meta: Meta<typeof PaymentMethodCard> = {
       description: "Handler for when the card is clicked",
       control: "none",
     },
-    drawerContent: {
-      description: "Content to show in the dropdown menu",
+    drawer: {
+      description: "Content to show as the dropdown menu",
       control: "none",
     },
   },
@@ -65,15 +66,21 @@ const MastercardIcon = () => (
   </svg>
 );
 
-const commonDrawerContent = (
-  <>
+const commonDrawer = (
+  <Dropdown
+    inline
+    arrowIcon={false}
+    label={
+      <HiDotsVertical className="h-6 w-6 text-gray-400 hover:text-gray-600" />
+    }
+  >
     <DropdownItem onClick={() => console.log("Edit")}>
       Edit payment method
     </DropdownItem>
     <DropdownItem onClick={() => console.log("Delete")}>
       Delete payment method
     </DropdownItem>
-  </>
+  </Dropdown>
 );
 
 // Basic Examples
@@ -111,7 +118,7 @@ export const Clickable: Story = {
 export const WithDrawer: Story = {
   args: {
     ...WithVisa.args,
-    drawerContent: commonDrawerContent,
+    drawer: commonDrawer,
   },
 };
 
@@ -119,7 +126,7 @@ export const ClickableWithDrawer: Story = {
   args: {
     ...WithVisa.args,
     onClick: () => console.log("Card clicked"),
-    drawerContent: commonDrawerContent,
+    drawer: commonDrawer,
   },
 };
 
@@ -142,7 +149,7 @@ export const FullFeatured: Story = {
     expiryDate: "12/24",
     lastUpdated: "Mar 15, 2024",
     onClick: () => console.log("Card clicked"),
-    drawerContent: commonDrawerContent,
+    drawer: commonDrawer,
     children: (
       <div className="mt-2 text-sm text-gray-500 dark:text-gray-400">
         Default payment method


### PR DESCRIPTION
Relates to https://github.com/aspyn-io/ui-saleshub/issues/157

This pull request refactors the way dropdown menus are handled in the `PaymentMethodCard` component by replacing the `drawerContent` prop with a more flexible `drawer` prop. It also updates the Storybook stories to reflect this change, ensuring consistent usage and better composability for custom dropdown content.

### Component API refactor

* Renamed the `drawerContent` prop to `drawer` in the `PaymentMethodCard` component and its TypeScript interface, making the API more generic and flexible. [[1]](diffhunk://#diff-622ad62c72f227f46816ccbe18a22ba8e1970fe783dde4b2d364979e23c1785bL12-R10) [[2]](diffhunk://#diff-622ad62c72f227f46816ccbe18a22ba8e1970fe783dde4b2d364979e23c1785bL38-R36)
* Updated the component to render the new `drawer` prop directly instead of wrapping it in a `Dropdown`, allowing consumers to pass any custom dropdown or drawer implementation.

### Storybook updates

* Changed all Storybook stories and args to use the new `drawer` prop instead of `drawerContent`, ensuring consistency with the refactored component API. [[1]](diffhunk://#diff-7c5cf297f55a611713f9bb3ff8553c4f61c1b0a38ccc6429d404f3ff26c8fca6L34-R36) [[2]](diffhunk://#diff-7c5cf297f55a611713f9bb3ff8553c4f61c1b0a38ccc6429d404f3ff26c8fca6L114-R129) [[3]](diffhunk://#diff-7c5cf297f55a611713f9bb3ff8553c4f61c1b0a38ccc6429d404f3ff26c8fca6L145-R152)
* Refactored the shared dropdown menu implementation in stories from `commonDrawerContent` to `commonDrawer`, and updated its usage to match the new prop.

### Dependency cleanup

* Removed unused imports related to dropdowns and icons from the `PaymentMethodCard` component, as the dropdown implementation is now handled externally.