### PR TITLE
Add tagging as latest version while publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,3 +57,8 @@ jobs:
         run: npm publish --tag unstable
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag as latest
+        run: npm dist-tag add @aspyn-io/sdk@$VERSION latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds an extra step to the npm publish workflow to ensure that the latest version of the `@aspyn-io/sdk` package is tagged as `latest` after publishing.

Publishing workflow improvements:
* Added a new job step to tag the just-published `@aspyn-io/sdk` version as `latest` using `npm dist-tag add`, making it easier for users to install the most recent release by default. (.github/workflows/publish.yml)