### PR TITLE
Remove "N/A" suffix from TimeSlotButton label when not available

### DIFF
--- a/src/components/scheduling/TimeSlotButton.tsx
+++ b/src/components/scheduling/TimeSlotButton.tsx
@@ -44,7 +44,7 @@ export const TimeSlotButton: React.FC<TimeSlotButtonProps> = ({
           : "bg-gray-50 hover:bg-blue-50 text-gray-700 hover:text-blue-700 border-2 border-gray-200 hover:border-blue-300 cursor-pointer dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-blue-900/20 dark:hover:text-blue-400 dark:hover:border-blue-700"
       }`}
     >
-      {!isAvailable ? `${label} (N/A)` : label}
+      {label}
     </button>
   );
 };


### PR DESCRIPTION
This pull request makes a small change to the `TimeSlotButton` component. The label for unavailable time slots no longer appends "(N/A)" and now simply displays the original label.