### PR TITLE
Add showSelectedAppointmentCard prop to SchedulingSelector for conditional rendering

### DIFF
--- a/src/components/scheduling/SchedulingSelector.tsx
+++ b/src/components/scheduling/SchedulingSelector.tsx
@@ -96,6 +96,7 @@ interface SchedulingSelectorProps {
   disablePastNavigation?: boolean;
   minDate?: Date;
   preferencesLoading?: boolean; // Loading state for preferences and appointment card
+  showSelectedAppointmentCard?: boolean; // Allow hiding the selected appointment card
 
   // Custom labels for UI text (e.g., internationalization)
   customLabels?: CustomLabels;
@@ -137,6 +138,7 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
   disablePastNavigation = true,
   minDate,
   preferencesLoading = false,
+  showSelectedAppointmentCard = true,
   customLabels = {},
 }) => {
   // Current week being displayed
@@ -382,26 +384,28 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
               </div>
 
               {/* Selected Appointment Card */}
-              <SelectedAppointmentCard
-                selectedSlot={selectedSlot}
-                formatDate={formatDate}
-                selectedWindow={selectedWindow}
-                selectedTeam={selectedTeam}
-                selectedTechnician={selectedTechnician}
-                teamOptions={teamOptions || []}
-                technicianOptions={technicianOptions || []}
-                windowOptions={windowOptions || []}
-                onReserve={onReserve}
-                reserveButtonText={reserveButtonText}
-                reserveButtonDisabled={
-                  reserveButtonDisabled || !schedulableSlot
-                }
-                reserveLoading={reserveLoading}
-                reservedSlot={reservedSlot}
-                onCancelReservation={onCancelReservation}
-                cancelButtonText={cancelButtonText}
-                cancelLoading={cancelLoading}
-              />
+              {showSelectedAppointmentCard && (
+                <SelectedAppointmentCard
+                  selectedSlot={selectedSlot}
+                  formatDate={formatDate}
+                  selectedWindow={selectedWindow}
+                  selectedTeam={selectedTeam}
+                  selectedTechnician={selectedTechnician}
+                  teamOptions={teamOptions || []}
+                  technicianOptions={technicianOptions || []}
+                  windowOptions={windowOptions || []}
+                  onReserve={onReserve}
+                  reserveButtonText={reserveButtonText}
+                  reserveButtonDisabled={
+                    reserveButtonDisabled || !schedulableSlot
+                  }
+                  reserveLoading={reserveLoading}
+                  reservedSlot={reservedSlot}
+                  onCancelReservation={onCancelReservation}
+                  cancelButtonText={cancelButtonText}
+                  cancelLoading={cancelLoading}
+                />
+              )}
             </>
           )}
         </div>

--- a/src/components/scheduling/index.ts
+++ b/src/components/scheduling/index.ts
@@ -1,4 +1,6 @@
 export { SchedulingSelector } from "./SchedulingSelector";
+export { SelectedAppointmentCard } from "./SelectedAppointmentCard";
+export { useTimezoneFormat } from "./hooks/useTimezoneFormat";
 export type {
   TimePeriod,
   TimePeriodConfig,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,8 @@ export {
 // Scheduling
 export {
   SchedulingSelector,
+  SelectedAppointmentCard,
+  useTimezoneFormat,
   type TimePeriod,
   type TimePeriodConfig,
   type TimeSlot,

--- a/src/stories/SchedulingSelector.stories.tsx
+++ b/src/stories/SchedulingSelector.stories.tsx
@@ -894,3 +894,24 @@ export const CustomTimePeriods: Story = {
     },
   },
 };
+
+export const HiddenAppointmentCard: Story = {
+  render: (args: WrapperArgs) => <SchedulingSelectorWrapper {...args} />,
+  args: {
+    timePeriods: defaultTimePeriods,
+    windowOptions: mockWindowOptions,
+    timezone: "America/New_York",
+    showDateJumper: true,
+    showTimezoneInfo: true,
+    disablePastNavigation: true,
+    showSelectedAppointmentCard: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates hiding the selected appointment card by setting `showSelectedAppointmentCard={false}`. This is useful when you want to handle the appointment display and reservation actions in a custom way outside of the SchedulingSelector component. The preferences (time window, team, technician) are still shown when a slot is selected.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
<img width="1915" height="905" alt="image" src="https://github.com/user-attachments/assets/d8a8e7da-4d9c-466b-94a9-4be5b0d97d65" />

This pull request introduces a new option to control the visibility of the selected appointment card within the `SchedulingSelector` component, along with improvements to component exports and documentation. The main focus is enabling consumers of the scheduling UI to hide the appointment card if they want to handle appointment display or reservation actions elsewhere.

### SchedulingSelector component enhancements

* Added a new prop `showSelectedAppointmentCard` to `SchedulingSelectorProps` and implemented logic to conditionally render the `SelectedAppointmentCard` based on this prop. [[1]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR99) [[2]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR141) [[3]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR387) [[4]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR408)

### Component exports

* Exported `SelectedAppointmentCard` and the `useTimezoneFormat` hook from both `src/components/scheduling/index.ts` and the main `src/index.tsx` entry point, making them available for external use. [[1]](diffhunk://#diff-f90962d201ccdb989452b2e1ebca2544cca6b3e5ab96f910d2b9fd0199809e1cR2-R3) [[2]](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405R21-R22)

### Documentation and usage example

* Added a new story, `HiddenAppointmentCard`, to `SchedulingSelector.stories.tsx` to demonstrate and document how to hide the appointment card by setting `showSelectedAppointmentCard={false}`. This helps clarify use cases for custom appointment handling.