### PR TITLE
Add showCopyValueButton prop to MetadataEditor and update stories

### DIFF
--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -15,6 +15,7 @@ export interface MetadataEditorProps {
   onMetadataChange?: (metadata: Record<string, string>) => void;
   showEditButton?: boolean;
   showCopyButton?: boolean;
+  showCopyValueButton?: boolean;
   title?: string;
   className?: string;
 }
@@ -30,6 +31,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
   onMetadataChange,
   showEditButton = true,
   showCopyButton = true,
+  showCopyValueButton = true,
   title = "Metadata",
   className = "",
 }) => {
@@ -198,20 +200,22 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 {key.replace(/_/g, " ")}
               </h3>
               <div className="group relative">
-                <p className="text-sm text-gray-800 dark:text-gray-200 pr-8 break-words">
+                <p className={`text-sm text-gray-800 dark:text-gray-200 break-words ${showCopyValueButton ? 'pr-8' : ''}`}>
                   {value}
                 </p>
-                <button
-                  onClick={() => handleCopyMetadataValue(key, value)}
-                  className="absolute right-0 top-0 p-1.5 rounded-md opacity-0 group-hover:opacity-100 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
-                  title={`Copy ${key.replace(/_/g, " ")}`}
-                >
-                  {copiedMetadataValues.has(key) ? (
-                    <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
-                  ) : (
-                    <Copy className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
-                  )}
-                </button>
+                {showCopyValueButton && (
+                  <button
+                    onClick={() => handleCopyMetadataValue(key, value)}
+                    className="absolute right-0 top-0 p-1.5 rounded-md opacity-0 group-hover:opacity-100 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
+                    title={`Copy ${key.replace(/_/g, " ")}`}
+                  >
+                    {copiedMetadataValues.has(key) ? (
+                      <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+                    )}
+                  </button>
+                )}
               </div>
             </div>
           ))}

--- a/src/stories/MetadataEditor.stories.tsx
+++ b/src/stories/MetadataEditor.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
       control: "boolean",
       description: "Show copy button",
     },
+    showCopyValueButton: {
+      control: "boolean",
+      description: "Show copy button for individual values",
+    },
     title: {
       control: "text",
       description: "Section title",
@@ -39,6 +43,7 @@ export const Default: Story = {
     },
     showEditButton: true,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Metadata",
   },
 };
@@ -49,6 +54,7 @@ export const Loading: Story = {
     isLoading: true,
     showEditButton: true,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Metadata",
   },
 };
@@ -59,6 +65,7 @@ export const Empty: Story = {
     isLoading: false,
     showEditButton: true,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Metadata",
   },
 };
@@ -74,6 +81,7 @@ export const ReadOnly: Story = {
     },
     showEditButton: false,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Metadata",
   },
 };
@@ -91,6 +99,7 @@ export const WithLongValues: Story = {
     },
     showEditButton: true,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Metadata",
   },
 };
@@ -104,6 +113,23 @@ export const CustomTitle: Story = {
     },
     showEditButton: true,
     showCopyButton: true,
+    showCopyValueButton: true,
     title: "Custom Properties",
+  },
+};
+
+export const NoCopyValueButtons: Story = {
+  args: {
+    metadata: {
+      region: "US-West",
+      priority: "high",
+      version: "2.1.0",
+      active_users: "1247",
+      auto_renew: "true",
+    },
+    showEditButton: true,
+    showCopyButton: true,
+    showCopyValueButton: false,
+    title: "Metadata",
   },
 };


### PR DESCRIPTION
Default:
<img width="1149" height="589" alt="image" src="https://github.com/user-attachments/assets/352568b1-4586-45c1-aad9-502c3b6eeca6" />
Without button:
<img width="1615" height="381" alt="image" src="https://github.com/user-attachments/assets/53e0b5b9-a80c-460c-b2a5-757cc6b28a41" />


This pull request adds a new feature to the `MetadataEditor` component, allowing users to optionally display a copy button for individual metadata values. The changes introduce a new `showCopyValueButton` prop, update the component logic and styling to support this feature, and expand Storybook stories to demonstrate various configurations.

**MetadataEditor component enhancements:**

* Added a new `showCopyValueButton` prop to the `MetadataEditorProps` interface and set its default value to `true`, enabling control over the visibility of individual value copy buttons. [[1]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7R18) [[2]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7R34)
* Updated the rendering logic and styling in `MetadataEditor.tsx` to conditionally show a copy button next to each metadata value when `showCopyValueButton` is enabled. [[1]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7L201-R206) [[2]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7R218)

**Storybook updates:**

* Added the `showCopyValueButton` prop to Storybook controls and descriptions for `MetadataEditor`.
* Updated all existing stories to include the `showCopyValueButton` prop, and added a new story (`NoCopyValueButtons`) to demonstrate the component with individual value copy buttons disabled. [[1]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R46) [[2]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R57) [[3]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R68) [[4]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R84) [[5]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R102) [[6]](diffhunk://#diff-e0bf270c65ba19c32756772a1baf860a56a578aa2516e1cef5980ce0e2617b12R116-R135)