### PR TITLE
Ability to edit empty metadata

### DIFF
--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -52,7 +52,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
         }))
       );
     } else {
-      setEditedMetadata([]);
+      setEditedMetadata([{ key: "", value: "" }]);
     }
     setIsModalOpen(true);
   };
@@ -150,11 +150,91 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
 
   if (!hasMetadata) {
     return (
-      <div className={className}>
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-          No metadata available
-        </p>
-      </div>
+      <>
+        <div className={className}>
+          <div className="flex justify-between items-center border-b border-gray-200 dark:border-gray-700 pb-2 mb-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {title}
+            </h2>
+            {showEditButton && (
+              <Button
+                color="gray"
+                size="xs"
+                onClick={handleOpenModal}
+                title="Edit metadata"
+              >
+                <Edit className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+            No metadata available
+          </p>
+        </div>
+
+        <Modal
+          dismissible
+          show={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          size="xl"
+        >
+          <ModalHeader>Edit Metadata</ModalHeader>
+          <ModalBody>
+            <div className="space-y-4">
+              {editedMetadata.map((item, index) => (
+                <div key={index} className="flex gap-2 items-start">
+                  <div className="flex-1">
+                    <TextInput
+                      type="text"
+                      placeholder="Key"
+                      value={item.key}
+                      onChange={(e) =>
+                        handleMetadataKeyChange(index, e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <TextInput
+                      type="text"
+                      placeholder="Value"
+                      value={item.value}
+                      onChange={(e) =>
+                        handleMetadataValueChange(index, e.target.value)
+                      }
+                    />
+                  </div>
+                  <Button
+                    color="gray"
+                    size="sm"
+                    onClick={() => handleRemoveMetadataItem(index)}
+                    className="mt-0.5"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+
+              <Button
+                color="light"
+                onClick={handleAddMetadataItem}
+                className="w-full"
+              >
+                + Add another item
+              </Button>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <div className="flex gap-2 justify-end w-full">
+              <Button color="gray" onClick={() => setIsModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSaveMetadata} disabled={isSaving}>
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </ModalFooter>
+        </Modal>
+      </>
     );
   }
 
@@ -200,7 +280,11 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 {key.replace(/_/g, " ")}
               </h3>
               <div className="group relative">
-                <p className={`text-sm text-gray-800 dark:text-gray-200 break-words ${showCopyValueButton ? 'pr-8' : ''}`}>
+                <p
+                  className={`text-sm text-gray-800 dark:text-gray-200 break-words ${
+                    showCopyValueButton ? "pr-8" : ""
+                  }`}
+                >
                   {value}
                 </p>
                 {showCopyValueButton && (

--- a/src/stories/MetadataEditor.stories.tsx
+++ b/src/stories/MetadataEditor.stories.tsx
@@ -70,6 +70,25 @@ export const Empty: Story = {
   },
 };
 
+export const EmptyWithEditDisabled: Story = {
+  args: {
+    metadata: undefined,
+    isLoading: false,
+    showEditButton: false,
+    showCopyButton: true,
+    showCopyValueButton: true,
+    title: "Metadata",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When metadata is empty and edit is disabled, users cannot add metadata.",
+      },
+    },
+  },
+};
+
 export const ReadOnly: Story = {
   args: {
     metadata: {


### PR DESCRIPTION
This pull request enhances the `MetadataEditor` component by improving the user experience when no metadata is present and adding more robust editing capabilities. It also introduces a new Storybook story to cover the scenario where editing is disabled for empty metadata.

**Improvements to the Metadata Editor UI and Editing Experience:**

* When there is no metadata, the editor now displays a header with the title and an optional edit button, as well as a modal dialog that allows users to add new metadata entries. The modal includes controls for adding, editing, and removing key-value pairs, and a clear "Save" or "Cancel" action.
* The edited metadata state is initialized with a blank key-value pair when opening the modal for empty metadata, allowing users to start entering data immediately.
* Minor code formatting improvements for consistency in rendering metadata values.

**Storybook Coverage:**

* Added a new Storybook story, `EmptyWithEditDisabled`, to demonstrate the component's behavior when no metadata is present and editing is disabled. This helps ensure the UI is clear and uneditable in this state.

<img width="1902" height="954" alt="Screenshot 2025-10-23 at 10 44 56" src="https://github.com/user-attachments/assets/b47b7ad2-6d49-4419-8703-045ba43e3db5" />

<img width="1902" height="954" alt="Screenshot 2025-10-23 at 10 45 08" src="https://github.com/user-attachments/assets/f2890783-2154-43aa-acb5-35eae09259f1" />
