### PR TITLE
feat: add selectedTimePeriod prop to TimeWindowSelector and SchedulingSelector for contextual labels

### DIFF
--- a/src/components/scheduling/Preferences/TimeWindowSelector.tsx
+++ b/src/components/scheduling/Preferences/TimeWindowSelector.tsx
@@ -9,6 +9,7 @@ interface TimeWindowSelectorProps {
   selectedWindow?: string;
   onWindowChange?: (windowId: string) => void;
   formatDate: (date: Date | string, format: string) => string;
+  selectedTimePeriod?: string;
 }
 
 /**
@@ -40,12 +41,35 @@ const formatTimeString = (
   }
 };
 
+/**
+ * Gets a contextual label for "Any time window" based on the selected time period
+ */
+const getAnyWindowLabel = (selectedTimePeriod?: string): string => {
+  if (!selectedTimePeriod) {
+    return "Any time window";
+  }
+
+  const period = selectedTimePeriod.toLowerCase();
+  if (period === "morning") {
+    return "Any morning window";
+  } else if (period === "afternoon") {
+    return "Any afternoon window";
+  } else if (period === "anytime") {
+    return "Any time window";
+  }
+
+  return "Any time window";
+};
+
 export const TimeWindowSelector: React.FC<TimeWindowSelectorProps> = ({
   options,
   selectedWindow,
   onWindowChange,
   formatDate,
+  selectedTimePeriod,
 }) => {
+  const anyLabel = getAnyWindowLabel(selectedTimePeriod);
+
   const dropdownItems: DropdownItem[] = options.map((option) => {
     // Format the time window label using the formatDate function (timezone-aware)
     const formattedLabel = `${formatTimeString(
@@ -67,7 +91,7 @@ export const TimeWindowSelector: React.FC<TimeWindowSelectorProps> = ({
       items={dropdownItems}
       selected={selectedWindow}
       onSelect={(id) => onWindowChange?.(id)}
-      anyLabel="Any time window"
+      anyLabel={anyLabel}
     />
   );
 };

--- a/src/components/scheduling/SchedulingSelector.tsx
+++ b/src/components/scheduling/SchedulingSelector.tsx
@@ -100,6 +100,9 @@ interface SchedulingSelectorProps {
 
   // Custom labels for UI text (e.g., internationalization)
   customLabels?: CustomLabels;
+
+  // Selected time period from calendar (for contextual "Any time window" label)
+  selectedTimePeriod?: string;
 }
 
 export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
@@ -140,6 +143,7 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
   preferencesLoading = false,
   showSelectedAppointmentCard = true,
   customLabels = {},
+  selectedTimePeriod,
 }) => {
   // Current week being displayed
   const [currentWeekStart, setCurrentWeekStart] = useState<Date>(() => {
@@ -369,6 +373,7 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
                     selectedWindow={selectedWindow}
                     onWindowChange={onWindowChange}
                     formatDate={formatDate}
+                    selectedTimePeriod={selectedTimePeriod}
                   />
                 )}
 


### PR DESCRIPTION
This pull request enhances the contextual labeling of the "Any time window" option in the scheduling preferences UI. The main improvement is that the label now dynamically reflects the selected time period (e.g., "Any morning window" or "Any afternoon window") for a clearer user experience. This is achieved by passing the selected time period through the component hierarchy and generating the label accordingly.

**Contextual label improvements:**
* Added the `selectedTimePeriod` prop to both `TimeWindowSelector` and `SchedulingSelector` components, enabling them to receive and utilize the currently selected time period. [[1]](diffhunk://#diff-c5b7fbdc66f3a2c02cbfe32d3c5aa1a6d82b3732e6b257e8643f6f1a063bacaeR12) [[2]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR103-R105)
* Implemented the `getAnyWindowLabel` function in `TimeWindowSelector.tsx` to generate a contextual label for the "Any time window" dropdown option based on the selected time period.
* Updated the dropdown to display the contextual label by passing `anyLabel={anyLabel}` instead of a static string.
* Ensured the `selectedTimePeriod` prop is properly passed from `SchedulingSelector` to `TimeWindowSelector`. [[1]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR146) [[2]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bR376)