### PR TITLE
fix: add skipAutoAdvance parameter to onWeekChange for manual navigation

### DIFF
--- a/src/components/scheduling/SchedulingSelector.tsx
+++ b/src/components/scheduling/SchedulingSelector.tsx
@@ -45,7 +45,11 @@ interface SchedulingSelectorProps {
   loading: boolean;
 
   // Callback when week changes (user clicks prev/next or jumps to date)
-  onWeekChange: (weekStart: string, weekEnd: string) => void;
+  onWeekChange: (
+    weekStart: string,
+    weekEnd: string,
+    skipAutoAdvance?: boolean
+  ) => void;
 
   // Selection state - controlled
   selectedSlot: SelectedSlot | null;
@@ -223,7 +227,8 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
     onSlotSelect(null);
     onWeekChange(
       format(newWeekStart, "yyyy-MM-dd"),
-      format(newWeekEnd, "yyyy-MM-dd")
+      format(newWeekEnd, "yyyy-MM-dd"),
+      true // Skip auto-advance for manual navigation
     );
   };
 
@@ -236,7 +241,8 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
     onSlotSelect(null);
     onWeekChange(
       format(newWeekStart, "yyyy-MM-dd"),
-      format(newWeekEnd, "yyyy-MM-dd")
+      format(newWeekEnd, "yyyy-MM-dd"),
+      true // Skip auto-advance for manual navigation
     );
   };
 
@@ -252,7 +258,8 @@ export const SchedulingSelector: React.FC<SchedulingSelectorProps> = ({
       onSlotSelect(null);
       onWeekChange(
         format(sunday, "yyyy-MM-dd"),
-        format(newWeekEnd, "yyyy-MM-dd")
+        format(newWeekEnd, "yyyy-MM-dd"),
+        true // Skip auto-advance for manual navigation
       );
     },
     [onWeekChange, onSlotSelect]


### PR DESCRIPTION
This pull request updates the `SchedulingSelector` component to improve how week navigation is handled, specifically by allowing the caller to control whether auto-advance logic should be skipped when the user manually navigates weeks. The main changes involve updating the `onWeekChange` callback signature and its usage throughout the component.

**Scheduling logic improvements:**

* Updated the `onWeekChange` callback in the `SchedulingSelectorProps` interface to accept an optional `skipAutoAdvance` boolean parameter, allowing more granular control over week navigation behavior.
* Modified all calls to `onWeekChange` triggered by manual navigation (such as previous/next week or jumping to a specific date) to pass `true` for the new `skipAutoAdvance` parameter, ensuring auto-advance logic is skipped in these cases. [[1]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bL226-R231) [[2]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bL239-R245) [[3]](diffhunk://#diff-db376c83d7a6679911ae865c5ca521742862e29dd701c2bbd1923d19c2ee697bL255-R262)