### PR TITLE
Fix double click issue in SearchableSelect

### DIFF
--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -210,7 +210,7 @@ export const SearchableSelect: FC<SearchableSelectProps> & {
       handleSelectionChange,
       multiple,
     }),
-    [isOpen, searchTerm, selectedValues, multiple]
+    [isOpen, searchTerm, selectedValues, multiple, handleSelectionChange]
   );
 
   // Single-select display text


### PR DESCRIPTION
This pull request makes a minor improvement to the `SearchableSelect` component by updating the dependency array for a memoized callback. This ensures that the memoization correctly accounts for all relevant dependencies, which can help prevent subtle bugs related to stale closures.

* Updated the dependency array for the memoized callback in `SearchableSelect` to include `handleSelectionChange`, ensuring correct memoization and preventing potential stale references. (`src/components/SearchableSelect.tsx`)