### PR TITLE
feat: add maxHeight prop to SearchableSelect for dropdown scrolling

### DIFF
--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -53,6 +53,8 @@ export interface SearchableSelectProps {
   /** Whether this field is in an error state (affects styling). */
   error?: boolean;
   wrap?: boolean;
+  /** Maximum height for the dropdown (e.g., '240px', '15rem'). When set, enables scrolling. */
+  maxHeight?: string;
 }
 
 interface SearchableSelectContextValue {
@@ -96,6 +98,7 @@ export const SearchableSelect: FC<SearchableSelectProps> & {
   helperText,
   error = false,
   wrap = true,
+  maxHeight,
 }) => {
   // State
   const [isOpen, setIsOpen] = useState(false);
@@ -353,6 +356,7 @@ export const SearchableSelect: FC<SearchableSelectProps> & {
                 overflow-auto rounded-md border border-gray-200 bg-white shadow-lg
                 dark:border-gray-600 dark:bg-gray-700
               "
+              style={maxHeight ? { maxHeight } : undefined}
             >
               {children}
             </div>


### PR DESCRIPTION
Add optional [maxHeight](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to SearchableSelect component

Adds a new optional [maxHeight](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to the [SearchableSelect](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) component that allows consumers to set a maximum height for the dropdown menu. When specified, the dropdown will be constrained to the given height and become scrollable if content exceeds it.

Changes
Added [maxHeight?: string](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop to [SearchableSelectProps](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface
Applied [maxHeight](vscode-file://vscode-app/c:/Users/alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as inline style to the dropdown container when provided
Usage
// Default behavior (no max height constraint)
<SearchableSelect>...</SearchableSelect>

// With max height for scrollable dropdown
<SearchableSelect maxHeight="240px">...</SearchableSelect>
<SearchableSelect maxHeight="15rem">...</SearchableSelect>

Why
This provides flexibility for consumers to control dropdown behavior based on their specific use case - some dropdowns may have few options and don't need scrolling, while others with many options benefit from a constrained height.