### PR TITLE
fix: dropdown cut issue

### DIFF
--- a/src/components/AppointmentCard.tsx
+++ b/src/components/AppointmentCard.tsx
@@ -252,7 +252,7 @@ export const AppointmentCard = ({
         </div>
       </div>
       <div
-        className="transition-max-height duration-300 ease-in-out overflow-hidden"
+        className="transition-max-height duration-300 ease-in-out"
         style={{ maxHeight: `${maxHeight}px` }}
         ref={contentRef}
       >
@@ -290,12 +290,12 @@ export const AppointmentCard = ({
                         order.status === "SCHEDULED"
                           ? "info"
                           : order.status === "COMPLETED"
-                          ? "success"
-                          : order.status === "DEFERRED"
-                          ? "warning"
-                          : order.status === "CANCELLED"
-                          ? "failure"
-                          : "gray"
+                            ? "success"
+                            : order.status === "DEFERRED"
+                              ? "warning"
+                              : order.status === "CANCELLED"
+                                ? "failure"
+                                : "gray"
                       }
                       className="inline-block capitalize"
                     >


### PR DESCRIPTION
This pull request makes a minor adjustment to the styling of the `AppointmentCard` component by removing the `overflow-hidden` class from the container that handles height transitions.

**Before**
<img width="1226" height="730" alt="image" src="https://github.com/user-attachments/assets/3913da11-3ed6-4730-8063-ca39c02fbc3e" />

**After**
<img width="1228" height="786" alt="image" src="https://github.com/user-attachments/assets/f4ecb6e5-a66f-432b-80c4-f12c7b8b4f76" />
