### PR TITLE
Add support for importantFields to prioritize metadata display

### DIFF
--- a/src/stories/MetadataEditor.stories.tsx
+++ b/src/stories/MetadataEditor.stories.tsx
@@ -6,6 +6,11 @@ const meta = {
   component: MetadataEditor,
   tags: ["autodocs"],
   argTypes: {
+    importantFields: {
+      control: "object",
+      description:
+        "Optional ordered list of keys to pin to the top (in the given order)",
+    },
     isLoading: {
       control: "boolean",
       description: "Show loading skeleton",
@@ -150,5 +155,59 @@ export const NoCopyValueButtons: Story = {
     showCopyButton: true,
     showCopyValueButton: false,
     title: "Metadata",
+  },
+};
+
+export const WithImportantFields: Story = {
+  args: {
+    metadata: {
+      region: "US-West",
+      priority: "high",
+      source: "patch",
+      version: "2.1.0",
+      environment: "staging",
+      account_id: "acc_2f8d3c1a",
+      team: "Payments",
+      active_users: "1247",
+      auto_renew: "true",
+    },
+    importantFields: ["source", "environment", "account_id", "priority"],
+    showEditButton: true,
+    showCopyButton: true,
+    showCopyValueButton: true,
+    title: "Metadata",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pinned keys render first in the exact order provided, in both view mode and the edit modal.",
+      },
+    },
+  },
+};
+
+export const WithImportantFieldsMissingKeys: Story = {
+  args: {
+    metadata: {
+      region: "US-West",
+      priority: "high",
+      source: "patch",
+      version: "2.1.0",
+      environment: "staging",
+    },
+    importantFields: ["source", "environment", "account_id", "team"],
+    showEditButton: true,
+    showCopyButton: true,
+    showCopyValueButton: true,
+    title: "Metadata",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Missing important keys are ignored (only present keys get pinned).",
+      },
+    },
   },
 };


### PR DESCRIPTION
<img width="1911" height="912" alt="image" src="https://github.com/user-attachments/assets/c7264b36-9a82-43a8-a557-ab313468fec4" />

This pull request adds support for pinning and ordering important metadata fields at the top of the `MetadataEditor` component, both in view and edit modes. It introduces a new `importantFields` prop, updates the rendering logic to respect this order, and enhances Storybook stories to showcase and document the new feature.

**MetadataEditor enhancements:**

* Added an optional `importantFields` prop to the `MetadataEditor` component, allowing consumers to specify an ordered list of keys that should appear first.
* Implemented the `orderedEntries` utility function to ensure important fields are displayed in the specified order, with all other fields following. This logic is applied in both the view and edit modal. [[1]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7L43-R74) [[2]](diffhunk://#diff-18a8577feefa05da7efc28bc5b2d74326bfeccbba7abce33b391f0b4b3b18ac7L277-R299)
* Updated the component to use `orderedEntries` instead of `Object.entries` for rendering metadata items.

**Storybook and documentation improvements:**

* Added `importantFields` to Storybook controls and documentation for the `MetadataEditor` component.
* Introduced new stories (`WithImportantFields`, `WithImportantFieldsMissingKeys`) to demonstrate and document the behavior of pinned and missing important fields.