### PR TITLE
Metadata Editor - use title inside modal

### DIFF
--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -183,7 +183,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 color="gray"
                 size="xs"
                 onClick={handleOpenModal}
-                title={`Edit ${title} metadata`}
+                title={`Edit ${title}`}
               >
                 <Edit className="h-4 w-4" />
               </Button>

--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -287,7 +287,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 color="gray"
                 size="xs"
                 onClick={handleOpenModal}
-                title={`Edit ${title} metadata`}  
+                title={`Edit ${title}`}
               >
                 <Edit className="h-4 w-4" />
               </Button>

--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -334,7 +334,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
         onClose={() => setIsModalOpen(false)}
         size="xl"
       >
-        <ModalHeader>Edit Metadata</ModalHeader>
+        <ModalHeader>Edit {title}</ModalHeader>
         <ModalBody>
           <div className="space-y-4 max-h-[60vh] overflow-y-auto">
             {editedMetadata.map((item, index) => (

--- a/src/components/MetadataEditor.tsx
+++ b/src/components/MetadataEditor.tsx
@@ -183,7 +183,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 color="gray"
                 size="xs"
                 onClick={handleOpenModal}
-                title="Edit metadata"
+                title={`Edit ${title} metadata`}
               >
                 <Edit className="h-4 w-4" />
               </Button>
@@ -200,7 +200,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
           onClose={() => setIsModalOpen(false)}
           size="xl"
         >
-          <ModalHeader>Edit Metadata</ModalHeader>
+          <ModalHeader>Edit {title}</ModalHeader>
           <ModalBody>
             <div className="space-y-4 max-h-[60vh] overflow-y-auto">
               {editedMetadata.map((item, index) => (
@@ -287,7 +287,7 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
                 color="gray"
                 size="xs"
                 onClick={handleOpenModal}
-                title="Edit metadata"
+                title={`Edit ${title} metadata`}  
               >
                 <Edit className="h-4 w-4" />
               </Button>


### PR DESCRIPTION
This pull request makes a small UI improvement to the `MetadataEditor` component. The modal header now displays the dynamic `title` prop instead of the static text "Edit Metadata", making the editor more context-aware.

<img width="1909" height="964" alt="Screenshot 2026-07-10 at 15 18 54" src="https://github.com/user-attachments/assets/7563c5a7-3b44-442b-84fd-3ddbdb1852ca" />
